### PR TITLE
chore(docker): upgrade Python runtime and use pip autoremove-torrents instead of git repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.8.5-slim
 
 ARG GIT_REPO='https://github.com/dantebarba/autoremove-torrents.git'
-ARG BRANCH='dev'
+ARG BRANCH='master'
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
 FROM python:3.13-slim
 
+ARG VERSION='1.5.5'
+
 WORKDIR /app
 
-RUN pip install autoremove-torrents
+RUN pip install autoremove-torrents==$VERSION
 
-RUN apt update \
-&& apt install cron -y -q \
-&& apt clean
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends cron \
+ && rm -rf /var/lib/apt/lists/*
 
 ADD cron.sh /usr/bin/cron.sh
 RUN chmod +x /usr/bin/cron.sh
@@ -15,7 +17,7 @@ RUN touch /var/log/autoremove-torrents.log
 
 COPY config.example.yml config.yml
 
-ENV OPTS '-c /app/config.yml'
-ENV CRON '*/5 * * * *'
+ENV OPTS='-c /app/config.yml'
+ENV CRON='*/5 * * * *'
 
 ENTRYPOINT ["/bin/sh", "/usr/bin/cron.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,12 @@
-FROM python:3.8.5-slim
-
-ARG GIT_REPO='https://github.com/dantebarba/autoremove-torrents.git'
-ARG BRANCH='master'
+FROM python:3.13-slim
 
 WORKDIR /app
 
-RUN apt-get update \
-&& apt-get install git gcc cron -y -q \
-&& git clone $GIT_REPO && cd autoremove-torrents && git checkout $BRANCH && python3 setup.py install \
-&& apt-get purge gcc git -y \
-&& apt-get clean
+RUN pip install autoremove-torrents
+
+RUN apt update \
+&& apt install cron -y -q \
+&& apt clean
 
 ADD cron.sh /usr/bin/cron.sh
 RUN chmod +x /usr/bin/cron.sh


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded base Python runtime for security and compatibility.
  * Simplified container build by replacing multi-step source builds with a direct runtime package install.
  * Reduced build dependencies, installed cron, cleaned package cache, and ensured a runtime log file and provisioned config are present.
* **Stability**
  * Preserved existing startup behavior and cron scheduling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->